### PR TITLE
Make synonyms more readable

### DIFF
--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1083,9 +1083,14 @@
         background: #222!important;
     }
     
-    /* Make synonyms text more readable */
-    .SDZsVb, .lr_dct_more_btn {
+    /* Synonyms text */
+    .SDZsVb {
         color: #8BADEF !important;
+    }
+    
+    /* More button */
+    .lr_dct_more_btn {
+        color: #ccddff !important;
     }
 
 }

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1090,7 +1090,7 @@
     
     /* More button */
     .lr_dct_more_btn {
-        color: #ccddff !important;
+        color: #c1d6ff !important;
     }
 
 }

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1082,6 +1082,11 @@
     .sbibod button:hover {
         background: #222!important;
     }
+    
+    /* Make synonyms text more readable */
+    .SDZsVb, .lr_dct_more_btn {
+        color: #8BADEF !important;
+    }
 
 }
 @-moz-document regexp("https?://plus.google.(com|([a-z]{2}))(.[a-z]{2})?/u/0/_/notifications/frame\\?.*") {


### PR DESCRIPTION
The default dark synonyms text color was hard to see on the dark background