### PR TITLE
Fix 'People also ask' colours

### DIFF
--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1066,7 +1066,7 @@
     }
 
     /* People also ask */
-    ._qgo {
+    .m7VU0c {
         background: #1c1c1c !important;
         border-top-color: #303030 !important;
     }


### PR DESCRIPTION
Incorrect class names (presumably from updated classes on Google's end) caused the 'People also ask' section to display in white.